### PR TITLE
Remove product framing and fix vulnerability reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,22 +70,11 @@ You can also write any additional information you find relevant.
 
 ### Vulnerability
 
-You can create a **Vulnerability** issue in case you believe that the vulnerability has been introduced in the platform. Our development process consists of automated vulnerability management, including dependency checks, static analysis of the code, and penetration testing. We are using the most common CVE databases and monitoring CVEs through the [CVE Radar](https://www.cveradar.com/) tool.
+**Do not report an undisclosed vulnerability in a public issue.** Report it privately: open the **Security** tab of the affected repository and choose **Report a vulnerability**, or email [ilm@omnitrust.com](mailto:ilm@omnitrust.com). The [security policy](https://github.com/OmniTrustILM/.github/blob/main/SECURITY.md) describes what to include, when to expect a reply, and how disclosure is coordinated.
 
-When opening a new **Vulnerability** issue, please use the following template to provide relevant information:
-```
-**Describe the vulnerability**
-A clear and concise description of the vulnerability or security issue.
+The **Vulnerability** issue template is for vulnerabilities that are already public, such as a CVE raised by dependency or container image scanning.
 
-**Affected components**
-- Component / Version:
-
-**Link to the CVE description**
-Link or any further information on the vulnerability, consisting the impact and recommended actions to mitigate.
-
-**Additional context**
-Add any other context about the problem here.
-```
+Our development process includes automated vulnerability management: dependency checks, static analysis of the code, and penetration testing. We use the most common CVE databases and monitor CVEs through the [CVE Radar](https://www.cveradar.com/) tool.
 
 ## Commit rules
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ILM (Identity Lifecycle Management) is a platform for effective and efficient trust lifecycle management for companies of any size and individuals. One of its goals is to provide an easy and affordable way to secure digital communication and support information security in more and more connected world.
 
-ILM is released as a commercial open source project under the [MIT License](LICENSE.md).
-Additional features and services are available under subscription plans. If you are interested in subscription, please contact us through [OmniTrust Official Web](https://www.omnitrust.com) or use the [ILM Official email address](mailto:ilm@omnitrust.com) email address.
+ILM is open source software, released under the [MIT License](LICENSE.md).
 
 ILM is designed and developed by a team of PKI and information security enthusiasts with practical point of view on the certificate management in hybrid environments. PKI is the backbone of security in our daily communication and its security and easy management should be available to everyone.
 
@@ -110,8 +109,10 @@ Components in the platform act as microservices and the main approach is to keep
 
 ## Contribution
 
-Anyone can contribute to ILM and we would be happy to support you in that. See [Contribution Guide](CONTRIBUTING.md) for more information.
+Anyone can contribute to ILM and we would be happy to support you in that. See the [Contribution Guide](CONTRIBUTING.md) for more information.
+
+The project is run by its [maintainers](MAINTAINERS.md) under a published [governance model](GOVERNANCE.md), which describes how contributors become maintainers and how decisions are made.
 
 ## License
 
-The ILM platform is released under the [MIT License](LICENSE.md). Some connectors and user interfaces are released under their own licenses or subscriptions. Consult with us for more information.
+The ILM platform is released under the [MIT License](LICENSE.md). Each repository states its own license.


### PR DESCRIPTION
Drop the subscription and commercial references from the README introduction and license section, and link the maintainers and governance documents from the contribution section.

Point vulnerability reporting in the contribution guide at private security advisories instead of public issues.