### PR TITLE
Add ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,50 @@
+# Adopters
+
+This file records organizations that use the ILM platform, and how they use it.
+
+## Adoption profile
+
+ILM runs in production across:
+
+- Banking, insurance and financial services
+- Payment service providers
+- Qualified trust service providers operating under eIDAS and ETSI requirements
+- Public sector
+- Telecommunications
+- Automotive
+- Internet of Things
+
+## Why individual adopters are not named here
+
+This list is short by policy, not for lack of adoption.
+
+ILM manages the certificates and keys that protect its adopters' infrastructure. Naming an organization here would disclose which system guards that material, which most of our adopters treat as security-sensitive information. In regulated sectors — particularly qualified trust service providers — it can also carry supervisory implications. We do not publish an adopter's name without their explicit agreement, and we never ask for that agreement as a condition of support.
+
+Where there is a legitimate need and a confidentiality undertaking in place, we can provide named references privately. The list below grows only as adopters choose to opt in.
+
+## Adopters
+
+| Organization | Adoption level | What they use it for | Contact |
+|---|---|---|---|
+| _None listed publicly yet_ | | | |
+
+Adoption levels:
+
+- **Production** — running ILM to manage live certificate or key material
+- **Testing** — evaluating ILM in a non-production environment
+- **Development** — building against ILM's APIs, connectors or SDKs
+
+## Adding your organization
+
+If you use ILM and are willing to be named, we would value it. A public list helps other organizations — often in the same sector, facing the same constraints — judge whether the platform is a serious option for them. That is a question we cannot answer as credibly as you can.
+
+Open a pull request adding a row to the table above, or [start a discussion](https://github.com/orgs/OmniTrustILM/discussions) if you would rather talk it through first. Include:
+
+- Your organization's name, and a link if you would like one
+- Your adoption level from the list above
+- A sentence on what you use ILM for, at whatever level of detail you are comfortable with
+- Optionally, a contact — a person, a team alias, or nothing at all
+
+You are welcome to be vague. "A European payment service provider — production — certificate lifecycle management across internal PKI" is a useful entry. So is your name and nothing else.
+
+If you would rather be counted without being listed publicly, email **ilm@omnitrust.com**.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Anyone can contribute to ILM and we would be happy to support you in that. See t
 
 The project is run by its [maintainers](MAINTAINERS.md) under a published [governance model](GOVERNANCE.md), which describes how contributors become maintainers and how decisions are made.
 
+Organizations using ILM are recorded in [ADOPTERS.md](ADOPTERS.md), which also explains how to add your own.
+
 ## License
 
 The ILM platform is released under the [Apache License 2.0](LICENSE.md). Each repository states its own license.


### PR DESCRIPTION
Added `ADOPTERS.md` recording the sectors the platform runs in, the policy on naming individual organizations, the adoption levels used, and how an organization adds itself to the list.

Linked the file from the contribution section of `README.md`.

The adopters table is empty; entries are added as organizations opt in.